### PR TITLE
Make card overlay blur transition more subtle

### DIFF
--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -1,6 +1,6 @@
 export const CardOverlay = () => (
   <>
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,transparent,black_60%)]" />
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/35 to-transparent" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,transparent,black_60%)]" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-black/35 to-transparent" />
   </>
 );

--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -1,6 +1,6 @@
 export const CardOverlay = () => (
   <>
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-32 backdrop-blur-md [mask-image:linear-gradient(to_bottom,transparent,black_40%)]" />
-    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/50 to-transparent" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,transparent,black_60%)]" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/35 to-transparent" />
   </>
 );


### PR DESCRIPTION
Reduce blur intensity (md→sm), overlay height (h-32→h-24),
gradient opacity (black/50→black/35), and shift mask gradient
start point lower (40%→60%) for a softer, less intrusive look.

https://claude.ai/code/session_019C9jW51TzywcTVjsCeKz3s